### PR TITLE
Store operations optimization

### DIFF
--- a/core/context_test.go
+++ b/core/context_test.go
@@ -112,7 +112,7 @@ func TestServiceIsCreated(t *testing.T) {
 	mockIpvs.On("AddService", "127.0.0.1", uint16(80), uint16(syscall.IPPROTO_TCP), "sh").Return(nil)
 	mockDisco.On("Expose", vsID, "127.0.0.1", uint16(80)).Return(nil)
 
-	err := c.createService(vsID, options)
+	err := c.createService(vsID, options, false)
 	assert.NoError(t, err)
 	mockIpvs.AssertExpectations(t)
 	mockDisco.AssertExpectations(t)
@@ -127,7 +127,7 @@ func TestServiceIsCreatedWithShFlags(t *testing.T) {
 	mockIpvs.On("AddServiceWithFlags", "127.0.0.1", uint16(80), uint16(syscall.IPPROTO_TCP), "sh", gnl2go.U32ToBinFlags(gnl2go.IP_VS_SVC_F_SCHED_SH_FALLBACK|gnl2go.IP_VS_SVC_F_SCHED_SH_PORT)).Return(nil)
 	mockDisco.On("Expose", vsID, "127.0.0.1", uint16(80)).Return(nil)
 
-	err := c.createService(vsID, options)
+	err := c.createService(vsID, options, false)
 	assert.NoError(t, err)
 	mockIpvs.AssertExpectations(t)
 	mockDisco.AssertExpectations(t)
@@ -255,7 +255,7 @@ func TestServiceIsCreatedWithGenericCustomFlags(t *testing.T) {
 		gnl2go.U32ToBinFlags(gnl2go.IP_VS_SVC_F_SCHED1|gnl2go.IP_VS_SVC_F_SCHED2|gnl2go.IP_VS_SVC_F_SCHED3)).Return(nil)
 	mockDisco.On("Expose", vsID, "127.0.0.1", uint16(80)).Return(nil)
 
-	err := c.createService(vsID, options)
+	err := c.createService(vsID, options, false)
 	assert.NoError(t, err)
 	mockIpvs.AssertExpectations(t)
 	mockDisco.AssertExpectations(t)

--- a/core/options.go
+++ b/core/options.go
@@ -145,6 +145,9 @@ func (o *ServiceOptions) CompareStoreOptions(options *ServiceOptions) bool {
 	if o.Persistent != options.Persistent {
 		return false
 	}
+	if o.Fallback != options.Fallback {
+		return false
+	}
 	return true
 }
 

--- a/core/store.go
+++ b/core/store.go
@@ -189,6 +189,15 @@ func (s *Store) CreateService(vsID string, opts *ServiceOptions) error {
 	return nil
 }
 
+func (s *Store) UpdateService(vsID string, opts *ServiceOptions) error {
+	// put to store
+	if err := s.put(s.storeServicePath+"/"+vsID, opts, true); err != nil {
+		log.Errorf("error while put(update) service to store: %s", err)
+		return err
+	}
+	return nil
+}
+
 func (s *Store) CreateBackend(vsID, rsID string, opts *BackendOptions) error {
 	opts.VsID = vsID
 	// put to store

--- a/core/store.go
+++ b/core/store.go
@@ -113,20 +113,80 @@ func NewStore(storeURLs []string, storeServicePath, storeBackendPath string, syn
 }
 
 func (s *Store) Sync() {
+	services, backends, err := s.getStoreContent()
+	if err != nil {
+		log.Errorf("error while get data from ext-store: %s", err)
+		return
+	}
+	// synchronize context
+	s.ctx.Synchronize(services, backends, false)
+}
+
+// StoreSyncStatus store info about synchronization with ext-store
+type StoreSyncStatus struct {
+	// RemovedServices list of services that can be removed
+	RemovedServices []string `json:"removed_services"`
+	// RemovedBackends list of backends that can be removed
+	RemovedBackends []string `json:"removed_backends"`
+	// NeedUpdateServices list of services that can be updated
+	NeedUpdateServices []string `json:"need_update_services"`
+	// NeedUpdateBackends list of backends that can be updated
+	NeedUpdateBackends []string `json:"need_update_backends"`
+	// Status show final info about sync. May be 'need sync', 'ok'
+	Status string `json:"status"`
+}
+
+func (sync *StoreSyncStatus) CheckStatus() string {
+	if sync.NeedUpdateBackends != nil ||
+		sync.NeedUpdateServices != nil ||
+		sync.RemovedBackends != nil ||
+		sync.RemovedServices != nil {
+		return "need sync"
+	} else {
+		return "ok"
+	}
+}
+
+func (s *Store) StoreSyncStatus() (*StoreSyncStatus, error) {
+
+	services, backends, err := s.getStoreContent()
+	if err != nil {
+		return nil, err
+	}
+	return s.ctx.CompareWithStore(services, backends), nil
+}
+
+// UpdateStore update ext-kvstore
+func (s *Store) UpdateStore() error {
+	// build external services map
+	services, backends, err := s.getStoreContent()
+	if err != nil {
+		log.Errorf("error while get data from ext-store: %s", err)
+		return err
+	}
+
+	// synchronize context
+	if err = s.ctx.Synchronize(services, backends, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getStoreContent extract service and backend from ext-store
+func (s *Store) getStoreContent() (map[string]*ServiceOptions, map[string]*BackendOptions, error) {
 	// build external services map
 	services, err := s.getExternalServices()
 	if err != nil {
-		log.Errorf("error while get services: %s", err)
-		return
+		log.Errorf("error while get services form ext-store: %s", err)
+		return nil, nil, err
 	}
 	// build external backends map
 	backends, err := s.getExternalBackends()
 	if err != nil {
-		log.Errorf("error while get backends: %s", err)
-		return
+		log.Errorf("error while get backends form ext-store: %s", err)
+		return nil, nil, err
 	}
-	// synchronize context
-	s.ctx.Synchronize(services, backends)
+	return services, backends, nil
 }
 
 func (s *Store) getExternalServices() (map[string]*ServiceOptions, error) {

--- a/http.go
+++ b/http.go
@@ -172,3 +172,37 @@ func (h backendStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, opts)
 	}
 }
+
+type storeUpdateHandler struct {
+	store *core.Store
+}
+
+func (h storeUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.store != nil {
+		if err := h.store.UpdateStore(); err != nil {
+			writeError(w, err)
+		} else {
+			writeJSON(w, map[string]string{"status": "ok"})
+		}
+	} else {
+		writeError(w, core.ErrObjectNotFound)
+	}
+
+}
+
+type storeSyncStatusHandler struct {
+	store *core.Store
+}
+
+func (h storeSyncStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.store != nil {
+		if syncStatus, err := h.store.StoreSyncStatus(); err != nil {
+			writeError(w, err)
+		} else {
+			writeJSON(w, syncStatus)
+		}
+	} else {
+		writeError(w, core.ErrObjectNotFound)
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -105,11 +105,11 @@ func main() {
 
 	// While it's not strictly required, close IPVS socket explicitly.
 	defer ctx.Close()
-
+	var store *core.Store
 	// sync with external store
 	if storeURLs != nil && len(*storeURLs) > 0 {
 		urls := strings.Split(*storeURLs, ",")
-		store, err := core.NewStore(urls, *storeServicePath, *storeBackendPath, *storeSyncTime, *storeUseTLS, ctx)
+		store, err = core.NewStore(urls, *storeServicePath, *storeBackendPath, *storeSyncTime, *storeUseTLS, ctx)
 		if err != nil {
 			log.Fatalf("error while initializing external store sync: %s", err)
 		}
@@ -127,6 +127,8 @@ func main() {
 	r.Handle("/service", serviceListHandler{ctx}).Methods("GET")
 	r.Handle("/service/{vsID}", serviceStatusHandler{ctx}).Methods("GET")
 	r.Handle("/service/{vsID}/{rsID}", backendStatusHandler{ctx}).Methods("GET")
+	r.Handle("/store/sync", storeUpdateHandler{store}).Methods("GET")
+	r.Handle("/store/sync/status", storeSyncStatusHandler{store}).Methods("GET")
 	r.Handle("/metrics", promhttp.Handler()).Methods("GET")
 
 	log.Infof("setting up HTTP server on %s", *listen)


### PR DESCRIPTION
Context:
- remove\create vs\rs operation on external store is now allowed only with api requests
- add method to compare local data with external store data
- add error return in Synchronize
- small fixes
- fix tests
- add more logs

Http:
- add api request for force updating external store /store/sync
- add api request for compare local data with external store data

Store:
- add UpdateService method for modification service on external storage

Options:
- add compare Fallback options memory <> store